### PR TITLE
Set root folder for images

### DIFF
--- a/agencyos/src/fields.json
+++ b/agencyos/src/fields.json
@@ -34235,7 +34235,9 @@
         "files"
       ],
       "interface": "files",
-      "options": null,
+      "options": {
+        "folder": "179227d0-058e-4087-929c-0f99b23e379b"
+      },
       "display": "related-values",
       "display_options": null,
       "readonly": false,

--- a/agencyos/src/fields.json
+++ b/agencyos/src/fields.json
@@ -1727,7 +1727,9 @@
       "conditions": null,
       "translations": null,
       "display_options": null,
-      "options": null,
+      "options": {
+        "folder": "ed033970-538d-4034-9a70-332e90104178"
+      },
       "validation": null,
       "note": null,
       "validation_message": null,
@@ -3372,7 +3374,9 @@
       "conditions": null,
       "translations": null,
       "display_options": null,
-      "options": null,
+      "options": {
+        "folder": "ed033970-538d-4034-9a70-332e90104178"
+      },
       "validation": null,
       "note": null,
       "validation_message": null,
@@ -4508,7 +4512,9 @@
       "conditions": null,
       "translations": null,
       "display_options": null,
-      "options": null,
+      "options": {
+        "folder": "ed033970-538d-4034-9a70-332e90104178"
+      },
       "validation": null,
       "note": null,
       "validation_message": null,
@@ -29747,7 +29753,9 @@
       "conditions": null,
       "translations": null,
       "display_options": null,
-      "options": null,
+      "options": {
+        "folder": "179227d0-058e-4087-929c-0f99b23e379b"
+      },
       "validation": null,
       "note": null,
       "validation_message": null,
@@ -33554,7 +33562,9 @@
         "files"
       ],
       "interface": "files",
-      "options": null,
+      "options": {
+        "folder": "ed033970-538d-4034-9a70-332e90104178"
+      },
       "display": "related-values",
       "display_options": null,
       "readonly": false,


### PR DESCRIPTION
This PR addresses the need to set a root folder for images used in the frontend to make it accessible for the public. 

![image](https://github.com/directus-labs/directus-templates/assets/129249191/9695df36-b453-4a6b-8489-362df8d4ae01)

The following collections are affected by this change:
- block_columns_rows
- block_gallery
- block_hero
- block_step_items
- posts