### PR TITLE
Allow reading the ID field for Public Policy

### DIFF
--- a/simple-website-cms/src/permissions.json
+++ b/simple-website-cms/src/permissions.json
@@ -1683,6 +1683,7 @@
     "validation": null,
     "presets": null,
     "fields": [
+      "id",
       "first_name",
       "last_name",
       "avatar",


### PR DESCRIPTION
Allow reading of the directus_users.id field for the public policy. This is needed to be able to get the author of a post.